### PR TITLE
Fix parseInternalDate() to handle 1-digit days

### DIFF
--- a/simpleimap.py
+++ b/simpleimap.py
@@ -111,7 +111,7 @@ class __simplebase:
                  'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
 
         InternalDate = re.compile(
-                        r'(?P<day>[ 0123][0-9])-(?P<mon>[A-Z][a-z][a-z])-(?P<year>[0-9][0-9][0-9][0-9])'
+                        r'(?P<day>[ 0123]?[0-9])-(?P<mon>[A-Z][a-z][a-z])-(?P<year>[0-9][0-9][0-9][0-9])'
                         r' (?P<hour>[0-9][0-9]):(?P<min>[0-9][0-9]):(?P<sec>[0-9][0-9])'
                         r' (?P<zonen>[-+])(?P<zoneh>[0-9][0-9])(?P<zonem>[0-9][0-9])'
                         )

--- a/testsuite.py
+++ b/testsuite.py
@@ -16,6 +16,12 @@ class TestParseSummaryData(unittest.TestCase):
         """
         self.imap = simpleimap.SimpleImapSSL('imap.gmail.com')
 
+    def testDateExchange(self):
+        """
+        Tests parsing a date from some Exchange server (1 digit day).
+        """
+        self.assertTrue(self.imap.parseInternalDate('1-Jul-2015 17:30:49 +0200'))
+
     def testEmbeddedSubjectQuotes(self):
         """
         Tests a message with embedded double quotes in the Subject.


### PR DESCRIPTION
Stumbled on this on the 4th email processed by imap2maildir. I can't believe no one complained about this yet :suspect:.